### PR TITLE
service-login trigger

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -103,44 +103,62 @@ module.exports = function auth(opts,cb){
   })
 
 
-
   // default service login trigger
-  seneca.add({role:name,trigger:'service-login'},function(args,done){
-    var q = {}
-    if( args.identifier ) {
-      q[args.service+'_id']=args.identifier
+  seneca.add({role:name, trigger:'service-login'}, function (args, done) {
+    if (seneca.req.user.login) {
+      userent.load$({nick:seneca.req.user.login.nick}, seneca.err(done, function (user) {
+        var props = {
+          email:args.email,
+          name:args.name,
+          service:{}
+        }
+        props[args.service + '_id'] = args.identifier;
+        props.service[args.service] = {
+          credentials:args.credentials,
+          userdata:args.userdata,
+          when:args.when
+        }
+
+        user.data$(seneca.util.deepextend(user.data$(), props))
+        user.save$(done)
+      }))
     }
+    else {
+      var q = {}
+      if (args.identifier) {
+        q[args.service + '_id'] = args.identifier
+      }
 
-    userent.load$(q,seneca.err(done,function(user){
-      var props = {
-        nick:args.nick,
-        email:args.email,
-        name:args.name,
-        active:true,
-        service:{}
-      }
-      props[args.service+'_id']=args.identifier
+      userent.load$(q, seneca.err(done, function (user) {
+        var props = {
+          nick:args.nick,
+          email:args.email,
+          name:args.name,
+          active:true,
+          service:{}
+        }
+        props[args.service + '_id'] = args.identifier
 
-      props.service[args.service]={
-        credentials:args.credentials,
-        userdata:args.userdata,
-        when:args.when
-      }
-      
+        props.service[args.service] = {
+          credentials:args.credentials,
+          userdata:args.userdata,
+          when:args.when
+        }
 
-      if( !user ) {
-        useract.register( props, seneca.err(done,function(out){
-          done(null,out.user)
-        }))
-      }
-      else {
-        user.data$( seneca.util.deepextend( user.data$(), props ) )
-        user.save$( done )
-      }
-    }))
+
+        if (!user) {
+          useract.register(props, seneca.err(done, function (out) {
+            done(null, out.user)
+          }))
+        }
+        else {
+          user.data$(seneca.util.deepextend(user.data$(), props))
+          user.save$(done)
+        }
+      }))
+    }
   })
 
-  
   // add own action with service:foo for new services
   seneca.add({role:name,hook:'service-init'},function(args,done){
     var service_init = require('./'+args.service)
@@ -185,6 +203,7 @@ module.exports = function auth(opts,cb){
           res.cookie('oauth-url-prefix',prefix)
         }
 
+        seneca.req = req;
         passport.authenticate( service, conf, func)(req,res,next)
       }
     })


### PR DESCRIPTION
seneca 'service-login' trigger uses the service id to find a user and creates it otherwise. We should be able to just update the user details if that user is already logged in.

See the hack in  pp_auth[service](seneca.req = req;)
