### PR TITLE
Use "local" seneca instances within actions

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -248,10 +248,6 @@ module.exports = function auth( options ) {
   var content_url = checkurl(options.content)
 
 
-
-  var userent = seneca.make$('sys/user')
-  var useract = seneca.pin({role:'user',cmd:'*'})
-
   if( options.sendemail ) {
     seneca.depends(plugin,['mail'])
     var mailact = seneca.pin({role:'mail',cmd:'*'})
@@ -301,13 +297,14 @@ module.exports = function auth( options ) {
 
   // default service login trigger
   function trigger_service_login( args, done ) {
+    var seneca = this
     var q = {}
     if( args.identifier ) {
       q[args.service+'_id']=args.identifier
     }
     else return service.fail({code:'no_identifier'},done)
 
-    userent.load$(q,function(err,user){
+    seneca.make$('sys/user').load$(q,function(err,user){
       if( err ) return done(err);
 
       var props = {
@@ -326,7 +323,7 @@ module.exports = function auth( options ) {
       }
 
       if( !user ) {
-        useract.register( props, function(err,out){
+        seneca.act('role:user,cmd:register', props, function(err,out){
           if( err ) return done(err);
           done(null,out.user)
         })
@@ -349,16 +346,18 @@ module.exports = function auth( options ) {
 
 
   function wrap_user( args, done ) {
-    this.act({
+    var seneca = this
+
+    seneca.act({
       role:'util',
       cmd:'ensure_entity',
       pin:args.pin,
       entmap:{
-        user:userent,
+        user:seneca.make$('sys/user'),
       }
     })
 
-    this.wrap(args.pin,function(args,done){
+    seneca.wrap(args.pin,function(args,done){
       args.user = args.user || (args.req$ && args.req$.seneca && args.req$.seneca.user ) || null
       this.parent(args,done)
     })
@@ -376,10 +375,10 @@ module.exports = function auth( options ) {
     var req = args.req$
     var res = args.res$
 
-    useract.register(details,function(err,out){
+    seneca.act('role:user,cmd:register',details,function(err,out){
       if( err || !out.ok ) { return done(err,out); }
 
-      useract.login({nick:out.user.nick,auto:true},function(err,out){
+      seneca.act('role:user,cmd:login',{nick:out.user.nick,auto:true},function(err,out){
         if( err || !out.ok ) { return done(err,out); }
 
         if( options.sendemail ) {
@@ -423,7 +422,7 @@ module.exports = function auth( options ) {
     if( void 0 != nick )  args.nick  = nick;
     if( void 0 != email ) args.email = email;
 
-    useract.create_reset( args, function( err, out ) {
+    seneca.act('role:user,cmd:create_reset', args, function( err, out ) {
       if( err || !out.ok ) return done(err,out);
 
       if( options.sendemail ) {
@@ -447,7 +446,7 @@ module.exports = function auth( options ) {
 
     var token = args.data.token
 
-    useract.load_reset( {token:token}, function( err, out ) {
+    seneca.act('role:user,cmd:load_reset', {token:token}, function( err, out ) {
       if( err || !out.ok ) return done(err,out);
 
       done(null,{
@@ -465,7 +464,7 @@ module.exports = function auth( options ) {
     var password = args.data.password
     var repeat   = args.data.repeat
 
-    useract.execute_reset( {token:token,password:password,repeat:repeat}, function( err, out ) {
+    seneca.act('role:user,cmd:execute_reset', {token:token,password:password,repeat:repeat}, function( err, out ) {
       if( err || !out.ok ) return done(err,out);
 
       done(null,{
@@ -481,7 +480,7 @@ module.exports = function auth( options ) {
     var code = args.data.code
     var req = args.req$
 
-    useract.confirm( {code:code}, function( err, out ) {
+    seneca.act('role:user,cmd:confirm', {code:code}, function( err, out ) {
       if( err || !out.ok ) return done(err,out);
 
       return done(null,{
@@ -499,7 +498,7 @@ module.exports = function auth( options ) {
 
     function check_uniq(field,next) {
       if( data[field] ) {
-        userent.load$({nick:data[field]},function(err,user){
+        seneca.make$('sys/user').load$({nick:data[field]},function(err,user){
           if( err ) return next(err);
           if( user ) return next({ok:false,why:'user-exists-'+field})
           return next(null,field);
@@ -529,7 +528,7 @@ module.exports = function auth( options ) {
 
     var user = args.user
 
-    useract.change_password({user:user,password:args.data.password,repeat:args.data.repeat},function(err,out){
+    seneca.act('role:user,cmd:change_password',{user:user,password:args.data.password,repeat:args.data.repeat},function(err,out){
       if( err ) return done(err);
       return done(null,out)
     })
@@ -723,19 +722,20 @@ module.exports = function auth( options ) {
 
 
     function init_session(req,res,cb) {
+      var seneca = req.seneca
       //var token = req.cookies[options.tokenkey]
-      var token = req.seneca.cookies.get(options.tokenkey)
+      var token = seneca.cookies.get(options.tokenkey)
 
       if( token ) {
-        useract.auth({token:token},function(err,out){
+        seneca.act('role:user,cmd:auth',{token:token},function(err,out){
           if( err ) return cb(err);
 
           if( out.ok ) {
             req.user = {user:out.user,login:out.login}
-            req.seneca.user = out.user
-            req.seneca.login = out.login
+            seneca.user = out.user
+            seneca.login = out.login
 
-            adminlocal(req,req.seneca.user)
+            adminlocal(req,seneca.user)
 
             cb()
           }
@@ -883,23 +883,24 @@ module.exports = function auth( options ) {
 
 
     function route_logout(req,res,next) {
-      var clienttoken = req.seneca.cookies.get(options.tokenkey)
+      var seneca = req.seneca
+      var clienttoken = seneca.cookies.get(options.tokenkey)
       var servertoken
       res.seneca.cookies.set(options.tokenkey)
 
-      if( req.seneca ) {
-        servertoken = req.seneca.login && req.seneca.login.token
-        delete req.seneca.user
-        delete req.seneca.login
+      if( seneca ) {
+        servertoken = seneca.login && seneca.login.token
+        delete seneca.user
+        delete seneca.login
       }
 
       if( clienttoken ) {
-        useract.logout({token:clienttoken},logerr)
+        seneca.act('role:user,cmd:logout',{token:clienttoken},logerr)
       }
 
       if( servertoken && servertoken != clienttoken ) {
         seneca.log('auth','token-mismatch',clienttoken,servertoken)
-        useract.logout({token:servertoken},logerr)
+        seneca.act('role:user,cmd:logout',{token:servertoken},logerr)
       }
 
       try { req.logout() } catch(err) { logerr(err) }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -250,7 +250,6 @@ module.exports = function auth( options ) {
 
   if( options.sendemail ) {
     seneca.depends(plugin,['mail'])
-    var mailact = seneca.pin({role:'mail',cmd:'*'})
   }
 
 
@@ -382,7 +381,7 @@ module.exports = function auth( options ) {
         if( err || !out.ok ) { return done(err,out); }
 
         if( options.sendemail ) {
-          mailact.send( {code:options.email.code.register,
+          seneca.act('role:mail,cmd:send', {code:options.email.code.register,
                          to:out.user.email,
                          subject:options.email.subject.register,
                          content:{name:out.user.name,
@@ -426,7 +425,7 @@ module.exports = function auth( options ) {
       if( err || !out.ok ) return done(err,out);
 
       if( options.sendemail ) {
-        mailact.send( {code:options.email.code.create_reset,
+        seneca.act('role:mail,cmd:send', {code:options.email.code.create_reset,
                        to:out.user.email,
                        subject:options.email.subject.create_reset,
                        content:{name:out.user.name,

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -266,6 +266,7 @@ module.exports = function auth( options ) {
 
 
   function cmd_login( args, done ) {
+    var seneca = this
     var nick = args.nick || ( args.user && args.user.nick )
 
     if( nick && args.auto ) {
@@ -683,11 +684,11 @@ module.exports = function auth( options ) {
         if (service != 'local') {
           if (!options.service[service].action || options.service[service].action == 'login') {
             func = function (err, user, info) {
-              seneca.act(_.extend({},user,{role: 'auth', trigger: 'service-login', service: service}),
+              req.seneca.act(_.extend({},user,{role: 'auth', trigger: 'service-login', service: service}),
                 function (err, user) {
                   if (err) return afterlogin(err,next,req,res);
 
-                  seneca.act({role: 'user', cmd: 'login', nick: user.nick, auto: true}, function (err,out) {
+                  req.seneca.act({role: 'user', cmd: 'login', nick: user.nick, auto: true}, function (err,out) {
                     req.user = out
                     afterlogin(err,next,req,res)
                   })
@@ -697,7 +698,7 @@ module.exports = function auth( options ) {
           }
           else {
             func = function (err, data, info) {
-              seneca.act({role: 'auth', trigger: 'service-' + options.service[service].action, service: service,
+              req.seneca.act({role: 'auth', trigger: 'service-' + options.service[service].action, service: service,
                   context: req.seneca.cookies.get(options.transientprefix + 'context'),
                   data: data
                 },
@@ -844,7 +845,7 @@ module.exports = function auth( options ) {
         else {
           // FIX: this should call instance
           // FIX: how to handle errors here?
-          seneca.act({role:plugin, cmd:'clean', user:req.seneca.user, login:req.seneca.login},function(err,out){
+          req.seneca.act({role:plugin, cmd:'clean', user:req.seneca.user, login:req.seneca.login},function(err,out){
 
             out.ok = true
 

--- a/lib/local.js
+++ b/lib/local.js
@@ -7,8 +7,10 @@ var LocalStrategy = passport_local.Strategy
 module.exports = function (conf, passport, done) {
   var seneca = this
 
-  passport.use(new LocalStrategy(
-    function (username, password, done) {
+  passport.use(new LocalStrategy({passReqToCallback: true},
+    function (req, username, password, done) {
+      var seneca = req.seneca
+
       seneca.act({role: 'user', cmd: 'login', nick: username, email: username, password: password}, 
                  function( err, out ){
                    done( !out.ok?out:null, out )


### PR DESCRIPTION
These changes allow the transaction ID (tx$) to be properly propagated between all actions involved in the processing of the client request.