### PR TITLE
Add ability to disable default plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A user authentication plugin, using [PassportJS](http://passportjs.org) for Expr
   * [Install](#install)
   * [Migration guide](#migration-guide)
   * [Plugins and modules](#plugins-and-modules)
+    * [Disabling default plugins](#disabling-default-plugins)
   * [Note about node version support](#note-about-node-version-support)
   * [Options deprecated or no longer supported](#options-deprecated-or-no-longer-supported)
   * [Restrict Login](#restrict-login)
@@ -62,7 +63,7 @@ A large part of the internal functionality of seneca-auth is now implemented as 
 
 |        Functionality    | Loaded by default |                                 plugin                                                      |
 |-------------------------|-------------------|---------------------------------------------------------------------------------------------|
-| Local strategy auth     | No                | [seneca-local-auth](https://github.com/senecajs/seneca-local-auth)                   |
+| Local strategy auth     | Yes               | [seneca-local-auth](https://github.com/senecajs/seneca-local-auth)                   |
 | Facebook  strategy auth | No                | [seneca-facebook-auth](https://github.com/senecajs/seneca-facebook-auth)                    |
 | Github strategy auth    | No                | [seneca-github-auth](https://github.com/senecajs/seneca-github-auth)                        |
 | Google  strategy auth   | No                | [seneca-google-auth](https://github.com/senecajs/seneca-google-auth)                        |
@@ -75,6 +76,17 @@ A large part of the internal functionality of seneca-auth is now implemented as 
 | Restrict Login          | No                | [auth-restrict-login](https://github.com/senecajs/auth-restrict-login) |
 
 Check the documentation of each plugin for details.
+
+## Disabling default plugins
+
+Disable default plugins by setting the flags on `options.default_plugins` to false. For example, if you want to use [auth-token-header](https://github.com/senecajs/auth-token-header) instead of [auth-token-cookie](https://github.com/senecajs/auth-token-cookie):
+
+```js
+seneca.use(require('seneca-auth', {
+    default_plugins: { authTokenCookie: false }
+})
+seneca.use(require('auth-token-header'))
+```
 
 # Note about node version support
 

--- a/auth.js
+++ b/auth.js
@@ -4,7 +4,7 @@
 // External modules.
 var _ = require('lodash')
 var AuthUrlmatcher = require('auth-urlmatcher')
-var AuthToken = require('auth-token-cookie')
+var AuthTokenCookie = require('auth-token-cookie')
 
 // Internal modules
 var UserManagement = require('./lib/user-management')
@@ -36,23 +36,34 @@ module.exports = function auth (opts) {
   internals.options = seneca.util.deepextend(DefaultOptions, opts)
 
   internals.load_common_plugins = function () {
-    seneca.use(AuthToken, internals.options)
-    seneca.use(AuthUrlmatcher, internals.options)
+    const plugins = internals.options.default_plugins
+    if (plugins.authTokenCookie) {
+      seneca.use(AuthTokenCookie, internals.options)
+    }
+    if (plugins.authUrlmatcher) {
+      seneca.use(AuthUrlmatcher, internals.options)
+    }
     seneca.use(Utility, internals.options)
     seneca.use(UserManagement, internals.options)
-    seneca.use(AuthRedirect, internals.options.redirect || {})
+    if (plugins.authRedirect) {
+      seneca.use(AuthRedirect, internals.options.redirect || {})
+    }
   }
 
   internals.load_default_express_plugins = function () {
     internals.load_common_plugins()
     seneca.use(ExpressAuth, internals.options)
-    seneca.use(LocalStrategy, internals.options)
+    if (internals.options.default_plugins.localAuth) {
+      seneca.use(LocalStrategy, internals.options)
+    }
   }
 
   internals.load_default_hapi_plugins = function () {
     internals.load_common_plugins()
     seneca.use(HapiAuth, internals.options)
-    seneca.use(LocalStrategy, internals.options)
+    if (internals.options.default_plugins.localAuth) {
+      seneca.use(LocalStrategy, internals.options)
+    }
   }
 
   internals.choose_framework = function () {

--- a/default-options.js
+++ b/default-options.js
@@ -5,6 +5,8 @@ module.exports = {
 
   framework: 'express',
 
+  // Register (true) default plugins. Set false to not register when
+  // using custom versions.
   default_plugins: {
     authRedirect: true,
     authTokenCookie: true,

--- a/default-options.js
+++ b/default-options.js
@@ -4,6 +4,14 @@ module.exports = {
   },
 
   framework: 'express',
+
+  default_plugins: {
+    authRedirect: true,
+    authTokenCookie: true,
+    authUrlmatcher: true,
+    localAuth: true
+  },
+
   prefix: '/auth/',
 
   urlpath: {


### PR DESCRIPTION
I couldn't find a way to disable the auth-token-cookie plugin. This PR provides the ability in the same manner like in the seneca main module.